### PR TITLE
Add feature - Custom rename schemes

### DIFF
--- a/XCI Organizer/Form1.Designer.cs
+++ b/XCI Organizer/Form1.Designer.cs
@@ -85,6 +85,8 @@
             this.BT_BatchTrim = new System.Windows.Forms.Button();
             this.B_UpdateNSWDB = new System.Windows.Forms.Button();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.R_BatchRenameCustomText = new System.Windows.Forms.TextBox();
+            this.R_BatchRenameCustom = new System.Windows.Forms.RadioButton();
             this.R_BatchRenameScene = new System.Windows.Forms.RadioButton();
             this.R_BatchRenameDetailed = new System.Windows.Forms.RadioButton();
             this.BT_BatchRename = new System.Windows.Forms.Button();
@@ -640,6 +642,8 @@
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.R_BatchRenameCustomText);
+            this.groupBox2.Controls.Add(this.R_BatchRenameCustom);
             this.groupBox2.Controls.Add(this.R_BatchRenameScene);
             this.groupBox2.Controls.Add(this.R_BatchRenameDetailed);
             this.groupBox2.Controls.Add(this.BT_BatchRename);
@@ -650,6 +654,26 @@
             this.groupBox2.TabIndex = 4;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Rename Options";
+            // 
+            // R_BatchRenameCustomText
+            // 
+            this.R_BatchRenameCustomText.Location = new System.Drawing.Point(98, 146);
+            this.R_BatchRenameCustomText.Name = "R_BatchRenameCustomText";
+            this.R_BatchRenameCustomText.Size = new System.Drawing.Size(192, 20);
+            this.R_BatchRenameCustomText.TabIndex = 7;
+            this.R_BatchRenameCustomText.Text = "[%ID%] %NAME%";
+            this.R_BatchRenameCustomText.Enter += new System.EventHandler(this.R_BatchRenameCustomText_Enter);
+            // 
+            // R_BatchRenameCustom
+            // 
+            this.R_BatchRenameCustom.AutoSize = true;
+            this.R_BatchRenameCustom.Location = new System.Drawing.Point(18, 146);
+            this.R_BatchRenameCustom.Name = "R_BatchRenameCustom";
+            this.R_BatchRenameCustom.RightToLeft = System.Windows.Forms.RightToLeft.No;
+            this.R_BatchRenameCustom.Size = new System.Drawing.Size(60, 17);
+            this.R_BatchRenameCustom.TabIndex = 6;
+            this.R_BatchRenameCustom.Text = "Custom";
+            this.R_BatchRenameCustom.UseVisualStyleBackColor = true;
             // 
             // R_BatchRenameScene
             // 
@@ -844,6 +868,8 @@
         private System.Windows.Forms.ToolStripMenuItem autoRenameFileToolStripMenuItem;
         private System.Windows.Forms.Button B_UpdateNSWDB;
         private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.TextBox R_BatchRenameCustomText;
+        private System.Windows.Forms.RadioButton R_BatchRenameCustom;
         private System.Windows.Forms.RadioButton R_BatchRenameScene;
         private System.Windows.Forms.RadioButton R_BatchRenameDetailed;
         private System.Windows.Forms.RadioButton R_BatchRenameSimple;

--- a/XCI Organizer/Form1.Designer.cs
+++ b/XCI Organizer/Form1.Designer.cs
@@ -613,7 +613,7 @@
             // 
             this.groupBox3.Controls.Add(this.BT_BatchTrim);
             this.groupBox3.Controls.Add(this.B_UpdateNSWDB);
-            this.groupBox3.Location = new System.Drawing.Point(141, 202);
+            this.groupBox3.Location = new System.Drawing.Point(141, 225);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(300, 151);
             this.groupBox3.TabIndex = 5;
@@ -650,7 +650,7 @@
             this.groupBox2.Controls.Add(this.R_BatchRenameSimple);
             this.groupBox2.Location = new System.Drawing.Point(141, 17);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(300, 165);
+            this.groupBox2.Size = new System.Drawing.Size(300, 188);
             this.groupBox2.TabIndex = 4;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Rename Options";

--- a/XCI Organizer/Form1.cs
+++ b/XCI Organizer/Form1.cs
@@ -925,6 +925,14 @@ namespace XCI_Organizer {
             }
         }
 
+        private void R_BatchRenameCustomText_Enter(object sender, EventArgs e)
+        {
+            TextBox tb = (TextBox)sender;
+            ToolTip tt = new ToolTip();
+            int VisibleTime = 7000;
+            tt.Show("Options:\n%ID%\n%NAME%\n%PUBLISHER%\n%GROUP%\n%REGION%\n%LANGUAGES%\n%SERIAL%\n%TITLEID%\n%RELEASENAME%\n%FIRMWARE%", tb, 0, 20, VisibleTime);
+        }
+
         private void BT_BatchRename_Click(object sender, EventArgs e) {
             // Added back into main function because I was trying to debug it. Needs to be added into Util again
             string selectedPath = ini.IniReadValue("Config", "BaseFolder");
@@ -970,9 +978,14 @@ namespace XCI_Organizer {
                     if (node != null) {
                         var id = node["id"].InnerText;
                         var name = node["name"].InnerText;
+                        var publisher = node["publisher"].InnerText;
+                        var group = node["group"].InnerText;
                         var region = node["region"].InnerText;
                         var languages = node["languages"].InnerText;
+                        var serial = node["serial"].InnerText;
+                        var titleid = node["titleid"].InnerText;
                         var releaseName = node["releasename"].InnerText;
+                        var firmware = node["firmware"].InnerText;
                         string nameScheme;
 
                         // Change region to something more human
@@ -998,8 +1011,23 @@ namespace XCI_Organizer {
                         else if (R_BatchRenameDetailed.Checked) {
                             nameScheme = id.ToString().PadLeft(4, '0') + " - " + name + " (" + region + ") (" + languages + ")";
                         }
-                        else {
+                        else if (R_BatchRenameScene.Checked)
+                        {
                             nameScheme = releaseName;
+                        }
+                        else
+                        {
+                            nameScheme = R_BatchRenameCustomText.Text
+                                .Replace("%ID%", id.ToString().PadLeft(4, '0'))
+                                .Replace("%NAME%", name)
+                                .Replace("%PUBLISHER%", publisher)
+                                .Replace("%GROUP%", group)
+                                .Replace("%REGION%", region)
+                                .Replace("%LANGUAGES%", languages)
+                                .Replace("%SERIAL%", serial)
+                                .Replace("%TITLEID%", titleid)
+                                .Replace("%RELEASENAME%", releaseName)
+                                .Replace("%FIRMWARE%", firmware);
                         }
                         
                         checkedName = string.Join("", nameScheme.Split(invalidChars.ToArray())); ;


### PR DESCRIPTION
Closes #5 

Allows specifying a custom renaming scheme for files.

### Example:

Input |  Output
:--: | :--:
`%ID%_%NAME%_(%REGION%)` | `0003_ARMS_(World)`
`%ID%-%NAME%` | `0003-ARMS`
`%RELEASENAME%` | `ARMS.PROPER.NSW-BigBlueBox`

### Options:
```javascript
%ID%
%NAME%
%PUBLISHER%
%GROUP%
%REGION%
%LANGUAGES%
%SERIAL%
%TITLEID%
%RELEASENAME%
%FIRMWARE%
```